### PR TITLE
Adding django.db.utils.DatabaseError to except clause; adding models.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Releases
 ========
 
 * (master): changes since v1.0...
- * requires Django 1.7+ (no `models.py`)
+ * requires Django 1.7+ (no `models.py`; class hierarchy of DatabaseError)
 * v1.0 (2014/05/29): initial release with support for at least:
  * Python 2.6 - 2.7
  * Django 1.4 - 1.7

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Releases
 ========
 
 * (master): changes since v1.0...
- * requires Django 1.7+ (no `models.py`; class hierarchy of DatabaseError)
+ * Adding support for Django 1.7
 * v1.0 (2014/05/29): initial release with support for at least:
  * Python 2.6 - 2.7
- * Django 1.4 - 1.7
+ * Django 1.4

--- a/db_outage/middleware.py
+++ b/db_outage/middleware.py
@@ -4,7 +4,9 @@ import sys
 from django.conf import settings
 from django.core.mail import mail_admins
 from django.db import connection
-from django.db.utils import DatabaseError
+from django.db.utils import DatabaseError as django_DatabaseError
+
+import cx_Oracle
 
 from db_outage.views import DBOutage
 
@@ -30,7 +32,7 @@ class DBOutageMiddleware(object):
 
         try:
             self.ping_db()
-        except DatabaseError as exc:
+        except (django_DatabaseError, cx_Oracle.DatabaseError) as exc:
             msg = (
                 'Your application is having trouble connecting to the '
                 'database. Please investigate.'

--- a/db_outage/views.py
+++ b/db_outage/views.py
@@ -3,7 +3,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.views.generic.base import TemplateView
 
 try:
-    module_path, ctx_class = settings.DB_OUTAGE_CONTEXT.rsplit('.',1)
+    module_path, ctx_class = settings.DB_OUTAGE_CONTEXT.rsplit('.', 1)
     module = __import__(module_path, fromlist=[ctx_class])
     context = getattr(module, ctx_class)
 except AttributeError:
@@ -26,7 +26,7 @@ class DBOutage(TemplateView):
                 'We are experiencing technical difficulties. Our IT staff has '
                 'been notified.'
             )
-        ctx.update({'msg':msg})
+        ctx.update({'msg': msg})
         return context(
             self.request,
             ctx,


### PR DESCRIPTION
Adding django.db.utils.DatabaseError to except clause; adding models.py - support Django 1.7 as well as 1.4, rather than exclusively.